### PR TITLE
Wizard progress persisted using localstorage, effects and signals

### DIFF
--- a/frontend/src/app/features/tournament/pages/wizard/wizard.html
+++ b/frontend/src/app/features/tournament/pages/wizard/wizard.html
@@ -12,7 +12,7 @@
     (ngSubmit)="onSubmit($event)"
   >
     @switch (stepActive()) {
-      @case (1) {
+      @case (0) {
         <fieldset class="fieldset">
           <legend class="fieldset-legend">Nombre del Torneo</legend>
           <input
@@ -76,7 +76,7 @@
           </button>
         </div>
       }
-      @case (2) {
+      @case (1) {
         <fieldset class="fieldset">
           <legend class="fieldset-legend">Juego del torneo</legend>
           <select class="select w-full" formControlName="game">
@@ -122,7 +122,7 @@
           <button type="button" class="btn btn-primary" (click)="nextStep()">Continuar</button>
         </div>
       }
-      @case (3) {
+      @case (2) {
         <div class="grid grid-cols-2 gap-4">
           <fieldset class="fieldset">
             <legend class="fieldset-legend">Nombre</legend>

--- a/frontend/src/app/features/tournament/pages/wizard/wizard.ts
+++ b/frontend/src/app/features/tournament/pages/wizard/wizard.ts
@@ -1,5 +1,5 @@
-import { Component, effect, inject, signal } from '@angular/core';
-import { rxResource } from '@angular/core/rxjs-interop';
+import { Component, effect, inject, OnInit, signal } from '@angular/core';
+import { rxResource, toSignal } from '@angular/core/rxjs-interop';
 import {
   AbstractControl,
   FormArray,
@@ -20,12 +20,13 @@ import { Toaster } from '@shared/utils/toaster';
 import { TournamentFormDTO } from '@shared/interfaces/tournament';
 import { Router } from '@angular/router';
 import { TournamentUtils } from '@shared/utils/tournament-utils';
+import { debounceTime } from 'rxjs';
 
 @Component({
   imports: [ReactiveFormsModule, FormErrorLabel, DatePipe],
   templateUrl: './wizard.html',
 })
-export class Wizard {
+export class Wizard implements OnInit {
   private locationService = inject(LocationService);
   private tagService = inject(TagService);
   private gameService = inject(GameService);
@@ -62,7 +63,7 @@ export class Wizard {
     { name: 'Confirmación', isActive: signal<boolean>(false) },
   ];
 
-  stepActive = signal<number>(1);
+  stepActive = signal<number>(0);
 
   private readonly EXCLUSIVE_GROUPS: readonly string[][] = [
     [EVENT_TAGS.VIRTUAL.name, EVENT_TAGS.IN_PERSON.name],
@@ -148,19 +149,48 @@ export class Wizard {
   }
 
   nextStep() {
-    this.steps.at(this.stepActive())?.isActive.set(true);
     this.stepActive.set(this.stepActive() + 1);
+    this.steps.at(this.stepActive())?.isActive.set(true);
   }
 
   backStep() {
-    this.stepActive.set(this.stepActive() - 1);
     this.steps.at(this.stepActive())?.isActive.set(false);
+    this.stepActive.set(this.stepActive() - 1);
+  }
+
+  persistStep = effect(() => {
+    localStorage.setItem('currentStep', this.stepActive().toString());
+    console.log({ effectStep: this.stepActive().toString() });
+  });
+
+  formValue = toSignal(this.tournamentForm.valueChanges.pipe(debounceTime(500)));
+  persistTournament = effect(() => {
+    const value = this.formValue();
+    if (value) {
+      localStorage.setItem('partialTournament', JSON.stringify(value));
+    }
+  });
+
+  ngOnInit(): void {
+    const storedTournament = localStorage.getItem('partialTournament');
+    if (!storedTournament) return;
+
+    const parsedTournament = JSON.parse(storedTournament);
+    this.tournamentForm.reset(parsedTournament);
+
+    const tagIds = parsedTournament.tags ?? [];
+    tagIds.forEach((tagId: number) => this.tournamentTags.push(this.fb.control(tagId)));
+
+    const savedStep = localStorage.getItem('currentStep');
+    if (!savedStep) return;
+
+    const step = +savedStep;
+    this.stepActive.set(step);
+    this.steps.forEach((s, i) => s.isActive.set(i <= step));
   }
 
   onSubmit(event: Event) {
     event.preventDefault();
-
-    console.log(this.tournamentForm.value);
 
     if (this.tournamentForm.invalid) {
       this.tournamentForm.markAllAsTouched();
@@ -172,6 +202,8 @@ export class Wizard {
     this.tournamentService.createTournament(tournament).subscribe({
       next: (createdTournament) => {
         Toaster.success('Torneo creado correctamente');
+        localStorage.removeItem('currentStep');
+        localStorage.removeItem('partialTournament');
         this.router.navigate(['/tournament', createdTournament.id, 'overview']);
       },
       error: (message) => {


### PR DESCRIPTION
Added persistence of steps in wizard using local storage.
Now, whenever you leave and reenter the wizard, the tournament's configuration will be loaded. It resets whenver the tournament is created.
---
Things to be noted:
- Tournament Wizard's persistence does not acknowledge the user registered. It just loads the tournament from local storage.