### PR TITLE
Added bracket randomization functionality.

### DIFF
--- a/backend/src/bracket/brackets-mikro-db.ts
+++ b/backend/src/bracket/brackets-mikro-db.ts
@@ -99,11 +99,17 @@ export class MikroOrmDatabase implements CrudInterface {
     async delete<T extends keyof DataTypes>(table: T): Promise<boolean>
     async delete<T extends keyof DataTypes>(table: T, filter: Partial<DataTypes[T]>): Promise<boolean>
     async delete<T extends keyof DataTypes>(table: T, filter?: Partial<DataTypes[T]>): Promise<boolean> {
-        //! Ojo, esto puede borrar todo.
-        const entity = this.getEntity(table)
-        const records = await em.find(entity, filter ?? {})
-        await em.removeAndFlush(records)
-        return records.length > 0
+        try {
+            const entity = this.getEntity(table)
+            const records = await em.find(entity, filter ?? {})
+            if (records.length > 0) {
+                await em.removeAndFlush(records)
+            }
+            return true
+        } catch (error) {
+            console.error(`Error deleting from ${table}:`, error)
+            return false
+        }
     }
 
     private getEntity(table: string) {

--- a/backend/src/tournament/tournament.controller.ts
+++ b/backend/src/tournament/tournament.controller.ts
@@ -34,6 +34,15 @@ const TournamentSchema = z.object({
 const storage = new MikroOrmDatabase()
 const manager = new BracketsManager(storage)
 
+// Array shuffling using Fisher-Yates algorithm
+function shuffleArray<T>(array: T[]): T[] {
+    for (let i = array.length - 1; i > 0; i--) {
+        let j = Math.floor(Math.random() * (i + 1))
+        ;[array[i], array[j]] = [array[j], array[i]]
+    }
+    return array
+}
+
 async function findAll(req: Request, res: Response) {
     const page = req.query.page ? Number(req.query.page) : 1
     const pageSize = req.query.pageSize ? Number(req.query.pageSize) : 10
@@ -198,6 +207,51 @@ async function closeInscriptions(req: Request, res: Response) {
         settings: {
             seedOrdering: ['inner_outer'],
             size: getNearestPowerOfTwo(inscriptionNicknames.length),
+        },
+    })
+
+    const bracketData = await manager.get.tournamentData(id)
+
+    res.status(200).json({
+        message: 'Bracket created',
+        data: bracketData,
+    })
+}
+
+async function reshuffleBracket(req: RequestWithUser, res: Response) {
+    const id = Number.parseInt(req.params.id)
+    const tournament = await em.findOneOrFail(Tournament, { id }, { populate: ['inscriptions'] })
+
+    if (tournament.status !== TournamentStatus.CLOSED) {
+        const error = new Error('Tournament is not closed.')
+        ;(error as any).statusCode = 409
+        throw error
+    }
+
+    const { name, type, inscriptions } = tournament
+    const inscriptionNicknames = inscriptions.map((inscription) => inscription.nickname)
+
+    const stages = await storage.select('stage', { tournament_id: id })
+
+    if (!stages?.length) {
+        const error = new Error(`There's no bracket available for this tournament.`)
+        ;(error as any).statusCode = 500
+        throw error
+    }
+    const stageId = stages[0].id
+
+    await manager.delete.stage(stageId)
+
+    const shuffledInscription = shuffleArray(inscriptionNicknames)
+
+    await manager.create.stage({
+        name: tournament.name,
+        tournamentId: id,
+        type: tournament.type as StageType,
+        seeding: shuffledInscription,
+        settings: {
+            seedOrdering: ['inner_outer'],
+            size: getNearestPowerOfTwo(shuffledInscription.length),
         },
     })
 
@@ -408,4 +462,5 @@ export {
     startTournament,
     endTournament,
     cancelTournament,
+    reshuffleBracket,
 }

--- a/backend/src/tournament/tournament.entity.ts
+++ b/backend/src/tournament/tournament.entity.ts
@@ -39,8 +39,8 @@ export class Tournament extends BaseEntity {
     type!: TournamentTypeEnum
     @ManyToOne(() => User, { nullable: false })
     creator!: Rel<User>
-    @ManyToOne(() => Location, { nullable: false })
-    location!: Rel<Location>
+    @ManyToOne(() => Location, { nullable: true })
+    location?: Rel<Location>
     @ManyToOne(() => Region, { nullable: true })
     region?: Rel<Region>
     @ManyToOne(() => Game, { nullable: false })

--- a/backend/src/tournament/tournament.routes.ts
+++ b/backend/src/tournament/tournament.routes.ts
@@ -17,6 +17,7 @@ import {
     closeInscriptions,
     endTournament,
     cancelTournament,
+    reshuffleBracket,
 } from './tournament.controller.js'
 import { authenticationMiddleware } from '../auth/middlewares/authentication.middleware.js'
 import { isOwnerOrAdminMiddleware } from '../auth/middlewares/isOwnerOrAdmin.middleware.js'
@@ -43,6 +44,12 @@ tournamentRouter.post('/', authenticationMiddleware, wrapController(add))
 tournamentRouter.post('/create', authenticationMiddleware, wrapController(create))
 
 //* Bracket -> A bracket is generated when the inscriptions has been closed.
+tournamentRouter.post(
+    '/:id/bracket/change',
+    authenticationMiddleware,
+    isOwnerOrAdminMiddleware,
+    wrapController(reshuffleBracket),
+)
 
 //* Match
 // Find tournament's bracket

--- a/frontend/src/app/features/admin/pages/tournament/tournament-crud-modal/tournament-crud-modal.ts
+++ b/frontend/src/app/features/admin/pages/tournament/tournament-crud-modal/tournament-crud-modal.ts
@@ -54,7 +54,7 @@ export class TournamentCrudModal {
   fb = inject(FormBuilder);
 
   private readonly EXCLUSIVE_GROUPS: readonly string[][] = [
-    [EVENT_TAGS.VIRTUAL.name, EVENT_TAGS.PRESENTIAL.name],
+    [EVENT_TAGS.VIRTUAL.name, EVENT_TAGS.IN_PERSON.name],
     [EVENT_TAGS.HAS_PRIZE.name, EVENT_TAGS.NO_PRIZE.name],
   ];
 
@@ -144,7 +144,7 @@ export class TournamentCrudModal {
       (t) => t.name === EVENT_TAGS.VIRTUAL.name && tagIds.includes(t.id),
     );
     const hasPresencial = allTags.some(
-      (t) => t.name === EVENT_TAGS.PRESENTIAL.name && tagIds.includes(t.id),
+      (t) => t.name === EVENT_TAGS.IN_PERSON.name && tagIds.includes(t.id),
     );
     if (hasVirtual && hasPresencial) return 'mixed';
     if (hasVirtual) return 'virtual';

--- a/frontend/src/app/features/tournament/components/tabs/tabs.ts
+++ b/frontend/src/app/features/tournament/components/tabs/tabs.ts
@@ -1,6 +1,8 @@
+import { JsonPipe } from '@angular/common';
 import { Component, computed, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink, RouterLinkActive } from '@angular/router';
+import { AuthService } from '@features/auth/services/auth.service';
 import { TournamentService } from '@shared/services/tournament.service';
 
 @Component({
@@ -11,6 +13,8 @@ import { TournamentService } from '@shared/services/tournament.service';
 export class Tabs {
   private tournamentService = inject(TournamentService);
   private activatedRoute = inject(ActivatedRoute);
+
+  private user = inject(AuthService).user;
 
   tournamentId = computed(() => Number(this.activatedRoute.snapshot.paramMap.get('id')));
   isCreator = toSignal(this.tournamentService.isLoggedUserCreator(this.tournamentId()), {
@@ -27,7 +31,7 @@ export class Tabs {
 
   // Tabs dinámicos basados en permisos
   tabs = computed(() => {
-    if (this.isCreator()) {
+    if (this.isCreator() || this.user()?.role.name === 'admin') {
       return [...this.baseTabs, this.adminTab];
     }
     return this.baseTabs;

--- a/frontend/src/app/features/tournament/pages/bracket/bracket.html
+++ b/frontend/src/app/features/tournament/pages/bracket/bracket.html
@@ -1,3 +1,11 @@
+@if (isCreator() && isClosed()) {
+  <div class="flex justify-center m-4">
+    <button class="btn btn-ghost hover:btn-primary" (click)="reshuffleBracket()">
+      Renovar bracket
+    </button>
+  </div>
+}
+
 <div class="flex mx-auto">
   <div #bracketContainer class="brackets-viewer"></div>
 </div>

--- a/frontend/src/app/features/tournament/pages/bracket/bracket.ts
+++ b/frontend/src/app/features/tournament/pages/bracket/bracket.ts
@@ -1,10 +1,11 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { TournamentService } from '@shared/services/tournament.service';
 import { Toaster } from '@shared/utils/toaster';
-import { rxResource } from '@angular/core/rxjs-interop';
-import { tap } from 'rxjs';
+import { rxResource, toSignal } from '@angular/core/rxjs-interop';
+import { map, tap } from 'rxjs';
 import { MatchModal } from '@features/tournament/components/match-modal/match-modal';
+import { JsonPipe } from '@angular/common';
 
 @Component({
   imports: [MatchModal],
@@ -17,7 +18,24 @@ export class Bracket {
   isModalOpen = signal<boolean>(false);
   matchData = signal({});
 
+  isCreator = toSignal(this.tournamentService.isLoggedUserCreator(Number(this.tournamentId())), {
+    initialValue: false,
+  });
+
   tournamentResource = rxResource({
+    params: () => ({ id: this.tournamentId() }),
+    stream: ({ params }) => {
+      const tournamentId = Number(params.id);
+
+      return this.tournamentService
+        .getTournament(tournamentId)
+        .pipe(map((response) => response.tournamentData));
+    },
+  });
+
+  isClosed = computed(() => this.tournamentResource.value()?.status === 'closed');
+
+  bracketResource = rxResource({
     params: () => ({ tournamentId: this.tournamentId() }),
     stream: ({ params }) => {
       return this.tournamentService
@@ -87,6 +105,14 @@ export class Bracket {
   refreshView() {
     console.log(this.tournamentService.bracketData().match.filter((m: any) => m.status !== 0));
     this.tournamentService.getTournamentBracket(+this.tournamentId()!).subscribe({
+      next: (data) => {
+        this.renderBracket(data);
+      },
+    });
+  }
+
+  reshuffleBracket() {
+    this.tournamentService.refreshBracket(+this.tournamentId()!).subscribe({
       next: (data) => {
         this.renderBracket(data);
       },

--- a/frontend/src/app/shared/services/tournament.service.ts
+++ b/frontend/src/app/shared/services/tournament.service.ts
@@ -260,4 +260,12 @@ export class TournamentService {
       catchError(() => of(false)),
     );
   }
+
+  refreshBracket(tournamentId: number): Observable<any> {
+    return this.http
+      .post<
+        ApiResponse<any>
+      >(`${environment.apiUrl}/tournaments/${tournamentId}/bracket/change`, {})
+      .pipe(map((response) => response.data));
+  }
 }


### PR DESCRIPTION
Added a button that displays on the 'brackets' tab on tournament. Clicking this button while the tournament is in the closed status (and the user logged is the tournament's owner) will result in a reshuffling the tournament matchups. Internally what this does is remove the tournament's stage and creating it again with a random setup.

In the backend an array shuffler function was implemented using the Fisher-Yates algorithm which ensures randomization.